### PR TITLE
fix translated_text to include choosen_translat column

### DIFF
--- a/db/migrate/20200930164725_create_translated_texts.rb
+++ b/db/migrate/20200930164725_create_translated_texts.rb
@@ -3,7 +3,7 @@ class CreateTranslatedTexts < ActiveRecord::Migration[6.0]
     create_table :translated_texts do |t|
       t.string :url
       t.string :instituction
-      t.date :deadline
+      t.boolean :choosen_translat
       t.string :service_title
       t.text :service
       t.integer :target_public

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2020_09_30_200813) do
   create_table "translated_texts", force: :cascade do |t|
     t.string "url"
     t.string "institution"
-    t.date "deadline"
+    t.boolean "choosen_translat"
     t.string "service_title"
     t.text "service"
     t.integer "target_public"


### PR DESCRIPTION
Pessoal, conforme conversamos, fiz a correcao na tabela translated_texts, para incluir o campo choosen_translat e excluir o campo deadline.
Por favor alguem confere ai