### PR TITLE
create action destroy to translated_text

### DIFF
--- a/app/controllers/translated_texts_controller.rb
+++ b/app/controllers/translated_texts_controller.rb
@@ -1,4 +1,5 @@
 class TranslatedTextsController < ApplicationController
+  before_action :set_translated, only: [:destroy]
 
   def show
     @review = TranslatedText.find(params[:id])
@@ -12,4 +13,24 @@ class TranslatedTextsController < ApplicationController
   def index
     @translated = TranslatedText.all
   end
+
+  def destroy
+    @translated.destroy
+    redirect_to translated_texts, notice: 'Pronto, sua sugestão de tradução foi apagada.'
+  end
+
+  private
+  # Use callbacks to share common setup or constraints between actions.
+
+  def set_translated
+    @translated = TranslatedText.find(params[:id])
+  end
+
+  def translated_params
+    params.require(:translated_text).permit(:url, :institution, :choosen_translat, :service_title, :service, :target_public, :service_stages, :more_info)
+  end
+
+
+
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 2020_10_01_184216) do
   create_table "translated_texts", force: :cascade do |t|
     t.string "url"
     t.string "institution"
-    t.date "deadline"
+    t.boolean "choosen_translat"
     t.string "service_title"
     t.text "service"
     t.text "target_public"


### PR DESCRIPTION
Pessoal essa tarefa estava sem dono no trello, ai eu atribui pra mim e implementei aqui. Eh a criacao do metodo destroy para translated_texts. Creio que esteja funcionando, mas so da pra gente testar mesmo quando tivermos o new e o create implementados. Quando o fabio liberar, testem ai
