### PR TITLE
Implement revisor area

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,9 +1,13 @@
 .card{
   background-color:#F8F8F8;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
   text-align:center;
   height:280px;
   margin:auto;
   margin-top: 10px;
+  width:100%;
   padding:10px 7px;
   border:1px solid rgb(240,240,240);
   box-shadow:1px 2px rgb(220,220,220);
@@ -41,8 +45,9 @@
   margin-bottom:20px;
   position:absolute;
   top:8px;
-  left:60px;
+  left:62px;
   font-size:15px;
+  text-align:center;
 }
 
 .datecard{
@@ -54,16 +59,19 @@
   font-size:15px;
 }
 
+.card_servtitle{
+  position:absolute;
+  top:70px;
+  left:10px;
+  right:10px;
+  text-align:center;
+}
+
 .cardcontent{
   position:absolute;
-  top:55px;
-  height:240px;
+  top:110px;
   margin-top:10px;
   text-align:justify;
-  h5{
-    margin-bottom:10px;
-    text-align:center;
-  }
   p{
     padding:0px 5px;
   }

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -121,3 +121,59 @@
 .evaltitle{
   color:#0c326f;
 }
+
+.dashcard{
+  background-color:#F8F8F8;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:space-between;
+  text-align:center;
+  height:280px;
+  margin:auto;
+  margin-top: 10px;
+  width:100%;
+  padding:10px 7px;
+  border:1px dotted #495057;
+  box-shadow:2px 2px #14213d;
+  border-radius:10px;
+  outline:none;
+  h5{
+    color:#0c326f;
+  }
+  p{
+    font-size:14px;
+    color:#212529;
+  }
+  a{
+    text-decoration:none;
+    color:#212529;
+  }
+  .dashlink{
+    color:#14213d;
+  }
+  .dashtitle{
+    margin-top:10px;
+    margin-bottom:20px;
+  }
+  .dashdate{
+    color:#0c326f;
+    font-weight:800;
+  }
+}
+
+.dashrevi, .dashsuge{
+  line-height:1;
+}
+
+.dashnumber{
+  font-size:20px;
+  color:#0c326f;
+  font-weight:800;
+}
+
+.dashdark{
+  background-color:#f5f3f4;
+  margin-top:0px;
+  padding:10px;
+}

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -10,5 +10,15 @@
 
 .formcamp{
   width:50px;
+}
 
+.writer-camp{
+  display:flex;
+  flex-direction:row;
+  align-items:center;
+  margin-bottom:20px;
+}
+
+.labelwc{
+  margin-left:10px;
 }

--- a/app/assets/stylesheets/components/_home.scss
+++ b/app/assets/stylesheets/components/_home.scss
@@ -19,9 +19,10 @@ i{
   font-size:30px !important;
   text-align:center !important;
   margin:5px auto;
-  // position:absolute;
-  // top:0px;
-  // left:40%;
+}
+
+.container{
+  margin-top:50px;
 }
 
 .links{

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   skip_before_action :authenticate_user!, only: [:home, :index, :show]
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password, :password_confirmation, :photo])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password, :password_confirmation, :photo, :is_writer, :cpf])
   end
 
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,4 +6,10 @@ class PagesController < ApplicationController
 
   def example
   end
+
+  def mypage
+    @mysubmitted = SubmittedText.all.select { |submitted| submitted.user_id == current_user.id }
+    @mytranslated = TranslatedText.all.select { |translated| translated.user_id == current_user.id}
+    @accepted = @mytranslated.select { |text| text.choosen_translat == true}
+  end
 end

--- a/app/controllers/submitted_texts_controller.rb
+++ b/app/controllers/submitted_texts_controller.rb
@@ -23,7 +23,7 @@ class SubmittedTextsController < ApplicationController
     @submitted.user_id = current_user.id
     @submitted.save
     if @submitted.save
-      redirect_to submitted_texts_path(@submitted)
+      redirect_to submitted_texts_path(@submitted), notice: 'Texto cadastrado com sucesso.'
     else
       render :new
     end

--- a/app/controllers/translated_texts_controller.rb
+++ b/app/controllers/translated_texts_controller.rb
@@ -16,7 +16,7 @@ class TranslatedTextsController < ApplicationController
     @translated.submitted_text = @submitted
     @translated.user = current_user
     if @translated.save
-      redirect_to submitted_text_path(@submitted)
+      redirect_to submitted_text_path(@submitted), notice: 'Sugestão cadastrada com sucesso.'
     else
       render :new
     end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,6 +8,9 @@
             required: true,
             autofocus: true,
             input_html: { autocomplete: "name" }%>
+    <div class="writer-camp">
+    <%= f.input_field :is_writer%><div class="labelwc">Sou um editor de serviços no gov.br</div>
+    </div>
     <%= f.input :email,
                 required: true,
                 autofocus: true,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,9 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
 

--- a/app/views/pages/mypage.html.erb
+++ b/app/views/pages/mypage.html.erb
@@ -1,0 +1,60 @@
+
+<div class='dashdark'>
+<div class="container">
+  <ul>
+    <li>Quantidade de sugestões postadas: <span class="dashnumber"><%=@mytranslated.size%></span></li>
+    <%if @accepted == 0%>
+      <li>Quantidade de sugestões aceitas: <span class="dashnumber"><%=@accepted.size%></span></li>
+    <%end%>
+  </ul>
+  <br>
+
+  <div class="row">
+    <%@mytranslated.each do |text|%>
+      <div class="col-xs-12 col-sm-6 col-md-3">
+        <a href=<%="submitted_texts/#{text.submitted_text_id}/translated_texts/#{text.id}"%>>
+        <div class="dashcard">
+          <h5 class="dashtitle"><%=text.service_title.truncate(45)%></h5>
+          <div class="dashcontent">
+            <h6><%=text.service.truncate(100).html_safe%></h6>
+          </div>
+          <div class="dashrevi">
+            <p><strong>Revisão do texto:</strong></p>
+            <p><a class="dashlink" href=<%="submitted_texts/#{text.submitted_text_id}"%>><%=text.submitted_text.service_title.truncate(45)%></a></p>
+          </div>
+          <div class="dashsuge">
+            <p><strong>Sugerido em:</strong></p>
+            <p class="dashdate"><%=format_date(text.created_at)%></p>
+          </div>
+        </div>
+        </a>
+      </div>
+    <%end%>
+  </div>
+</div>
+</div>
+
+<div class="container">
+  <%if current_user.is_writer == true%>
+  <ul>
+    <li>Quantidade de textos postados: <span class="dashnumber"><%=@mysubmitted.size%></span></li>
+  </ul>
+  <br>
+    <div class="row">
+      <%@mysubmitted.each do |text|%>
+        <div class="col-xs-12 col-sm-6 col-md-3">
+          <a href=<%="submitted_texts/#{text.id}"%>>
+          <div class="dashcard">
+            <h5 class="dashtitle"><%=text.service_title.truncate(45)%></h5>
+            <div class="dashcontent">
+              <p><%=text.service.truncate(100).html_safe%></p>
+              <p><strong>Sugestões até:</strong></p>
+              <p class="dashdate"><%=format_date(text.deadline)%></p>
+            </div>
+          </div>
+          </a>
+        </div>
+      <%end%>
+    </div>
+  <%end%>
+</div>

--- a/app/views/pages/mypage.html.erb
+++ b/app/views/pages/mypage.html.erb
@@ -3,7 +3,7 @@
 <div class="container">
   <ul>
     <li>Quantidade de sugestões postadas: <span class="dashnumber"><%=@mytranslated.size%></span></li>
-    <%if @accepted == 0%>
+    <%if @accepted.size > 0%>
       <li>Quantidade de sugestões aceitas: <span class="dashnumber"><%=@accepted.size%></span></li>
     <%end%>
   </ul>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -27,7 +27,9 @@
             </a>
           <div id="downcase" class="dropdown-menu" aria-labelledby="navbarDropdown">
               <%= link_to 'Ajudar alguém', submitted_texts_url, class: "dropdown-item" %>
-              <%= link_to 'Enviar um texto', new_submitted_text_path, class: "dropdown-item" %>
+              <%if user_signed_in? && current_user.is_writer == true%>
+                <%= link_to 'Enviar um texto', new_submitted_text_path, class: "dropdown-item" %>
+              <%end%>
               <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
           </div>
         </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -26,7 +26,7 @@
              <%=image_tag 'user.png', class: 'avatar'%>
             </a>
           <div id="downcase" class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <%= link_to 'Ajudar alguém', submitted_texts_url, class: "dropdown-item" %>
+              <%= link_to 'Minha Página', mypage_url, class: "dropdown-item" %>
               <%if user_signed_in? && current_user.is_writer == true%>
                 <%= link_to 'Enviar um texto', new_submitted_text_path, class: "dropdown-item" %>
               <%end%>

--- a/app/views/submitted_texts/index.html.erb
+++ b/app/views/submitted_texts/index.html.erb
@@ -5,9 +5,11 @@
     <h1>Olá visitante!</h1>
   <%end%>
 </div>
+<%if user_signed_in? && current_user.is_writer == true%>
 <div class="linkshome">
   <%= link_to 'Quero submeter um texto', new_submitted_text_path, class: "links" %>
 </div>
+<%end%>
 <div class="container">
   <br>
   <h1>Textos postados</h1>

--- a/app/views/submitted_texts/index.html.erb
+++ b/app/views/submitted_texts/index.html.erb
@@ -17,16 +17,16 @@
       <% if @submitteds != nil %>
         <div class="row">
           <% @submitteds.each do |submitted| %>
-            <div class="col-3">
+            <div class="col-xs-12 col-sm-6 col-lg-3">
               <a href=<%="/submitted_texts/#{submitted.id}"%>>
                 <div class="card">
                 <div class="iconbox"><i class='fas fa-file-alt'></i></div>
                   <h6 class="cardtitle">Sugestões até:</h6>
-                  <h6 class="datecard"><%= format_date(submitted.deadline) %></h6>
-                <div class="cardcontent">
+                  <h6 class="datecard"><%=format_date(submitted.deadline)%></h6>
+                  <h5 class="card_servtitle"><%=submitted.service_title.truncate(45).strip.gsub('.','')%></h5>
 
-                  <h5><%= submitted.service_title.truncate(45) %></h5>
-                  <p><%= submitted.service.truncate(160).html_safe %></p>
+                <div class="cardcontent">
+                  <p><%=submitted.service.truncate(160).html_safe%></p>
 
                 </div>
                 <div class="cardlinks">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
     end
   end
     get 'example', to: 'pages#example'
+    get 'mypage', to: 'pages#mypage'
 end


### PR DESCRIPTION
O dashboard para os textos e sugestões do usuário está implementado;
A questão das revisões sumirem após serem aceitas está feita;
A responsividade da página inicial está melhor, preciso que vocês testem para saber se está 100%;
A diferenciação entre editor e revisor está implementada, com a opção is_writer no formulário de signup (talvez vocês precisem esvaziar suas databases, ou então colocar is_writer = true para todos os users que tenham texto publicado).
A edição das sugestões também está pronta.


