### PR TITLE
envio de emails em modo producao

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -15,9 +15,9 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.new_translation.subject
   #
-  # def new_translation
-  #   @user = "Hi"
-
-  #   mail to: "to@example.org"
-  # end
+  def new_translation
+    @users = User.where(is_writer: false)
+    @users.each do |user|
+     mail(to: user.email, subject: 'Novo texto disponível')
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -18,6 +18,9 @@ class UserMailer < ApplicationMailer
   def new_translation
     @users = User.where(is_writer: false)
     @users.each do |user|
+      @user = user
      mail(to: user.email, subject: 'Novo texto disponível')
+
+   end
   end
 end

--- a/app/models/submitted_text.rb
+++ b/app/models/submitted_text.rb
@@ -1,4 +1,6 @@
 class SubmittedText < ApplicationRecord
+  after_create :send_new_text_email
+
   belongs_to :user
   has_many :translated_texts, dependent: :destroy
 
@@ -8,4 +10,10 @@ class SubmittedText < ApplicationRecord
     using: {
       tsearch: { prefix: true }
     }
+
+  private
+
+  def send_new_text_email
+    UserMailer.new_adoption(self).deliver_now
+  end
 end

--- a/app/models/submitted_text.rb
+++ b/app/models/submitted_text.rb
@@ -11,9 +11,10 @@ class SubmittedText < ApplicationRecord
       tsearch: { prefix: true }
     }
 
+
   private
 
   def send_new_text_email
-    UserMailer.new_adoption(self).deliver_now
+    UserMailer.new_translation.deliver_now
   end
 end

--- a/app/views/user_mailer/new_adoption.html.erb
+++ b/app/views/user_mailer/new_adoption.html.erb
@@ -1,9 +1,9 @@
 <h1>Ola, <%= @user.name %>, tudo bem com você?</h1>
 
-<h2>Temos boas notícias.</h2>
+<h2>Temos boas notícias!</h2>
 
 <p>
-  Seu texto foi adotado por um revisor. Isso signfifica
+  Seu texto foi revisado por um membro da comunidade Brasileirês. Isso significa
   que alguém pensa como você e quer ajudar a melhorar sua comunicação
   com o cidadão.
 </p>

--- a/app/views/user_mailer/new_translation.html.erb
+++ b/app/views/user_mailer/new_translation.html.erb
@@ -1,9 +1,10 @@
 <h1>Ola, <%= @user.name %>, tudo bem com você?</h1>
 
-<h2>Tem texto novo esperando tradução no Brasileirês</h2>
+<h2>Tem texto novo no Brasileirês!</h2>
 
 <p>
-  Acaba de ser postado na plataforma Brasileirês um novo texto, que precisa ser simplificado.
+  Acaba de ser postado um novo texto de serviço público, que precisa ser simplificado.
+  
   É a sua oportunidade de ajudar a melhorar a prestação dos serviços públicos e facilitar a vida dos cidadãos.
 </p>
 

--- a/app/views/user_mailer/new_translation.html.erb
+++ b/app/views/user_mailer/new_translation.html.erb
@@ -1,5 +1,10 @@
-<h1>User#new_translation</h1>
+<h1>Ola, <%= @user.name %>, tudo bem com você?</h1>
+
+<h2>Tem texto novo esperando tradução</h2>
 
 <p>
-  <%= @greeting %>, find me in app/views/user_mailer/new_translation.html.erb
+  Acaba de ser postado na plataforma Brasileirês um novo texto, que precisa ser simplificado.
+  É a sua oportunidade de ajudar a melhorar a prestação dos serviços públicos e facilitar a vida dos cidadãos.
 </p>
+
+<h3>Para saber mais, visite <%= link_to 'brasileires.com', root_url%> </h3>

--- a/app/views/user_mailer/new_translation.html.erb
+++ b/app/views/user_mailer/new_translation.html.erb
@@ -1,6 +1,6 @@
 <h1>Ola, <%= @user.name %>, tudo bem com você?</h1>
 
-<h2>Tem texto novo esperando tradução</h2>
+<h2>Tem texto novo esperando tradução no Brasileirês</h2>
 
 <p>
   Acaba de ser postado na plataforma Brasileirês um novo texto, que precisa ser simplificado.

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,0 +1,3 @@
+GMAIL_ADDRESS: 'projetobrasileires@gmail.com'
+GMAIL_APP_PASSWORD: 'tslnpkiegsjqypdi'
+

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,7 +1,7 @@
 Rails.application.configure do
   config.action_mailer.default_url_options = { host: "http://localhost:3000" }
   # Settings specified here will take precedence over those in config/application.rb.
-  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.delivery_method = :smtp
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,7 @@
 Rails.application.configure do
-  config.action_mailer.default_url_options = { host: "http://TODO_PUT_YOUR_DOMAIN_HERE" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = { host: "brasileires.herokuapp.com" }
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.

--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -1,0 +1,9 @@
+ActionMailer::Base.smtp_settings = {
+  address: "smtp.gmail.com",
+  port: 587,
+  domain: 'gmail.com',
+  user_name: ENV['GMAIL_ADDRESS'],
+  password: ENV['GMAIL_APP_PASSWORD'],
+  authentication: :login,
+  enable_starttls_auto: true
+}


### PR DESCRIPTION
Pessoal, primeira coisa: desculpem pela confusão que fiz sobre o que tinhamos combinado sobre o envio de emails. O Marcos tava certo (desculpa, Marcão). O que combinamos foi mandar um email para o dono do texto quando houvesse uma nova sugestao de traducao e um para cada um dos revisores quando fosse cadastrado um novo texto para revisar. quando olhei no trello vi que eu estava inventando coisa.

Bem, agora, conforme combinamos, implmententei essas duas features. Testem aí por favor. É só criar um novo submitted_text e checar a caixa de email dos que vcs cadastraram como revisores e criar uma nova sugestão de revisão e checar a caixa do dono do texto. Se quiserem revisar os textos dos emails tbm é so abrir codigo e ver as views.