### PR TITLE
deadline vira obrigatorio e com prazo padrao de 7 dias

### DIFF
--- a/app/models/submitted_text.rb
+++ b/app/models/submitted_text.rb
@@ -3,7 +3,7 @@ class SubmittedText < ApplicationRecord
 
   belongs_to :user
   has_many :translated_texts, dependent: :destroy
-
+  validates :deadline, presence: true
   include PgSearch::Model
   pg_search_scope :search_by_multiple_fields,
     against: [:institution, :service_title, :service, :target_public],

--- a/app/views/submitted_texts/new.html.erb
+++ b/app/views/submitted_texts/new.html.erb
@@ -17,6 +17,6 @@
   <h6 class="formlabel">Mais informações:</h6>
     <%= f.input :more_info, label: false, as: :ckeditor, input_html: { ckeditor: { toolbar: 'Full' } } %>
   <h6 class="formlabel">Prazo:</h6>
-    <%= f.input :deadline, label: false, as: :date, html5: true%>
+    <%= f.input :deadline, input_html: { value: Date.today+7 }, label: false, as: :date, html5: true%>
     <%= f.submit "Pedir Sugestões", :class => "btn-solicitar conforto" %>
 <% end %>


### PR DESCRIPTION
Pessoal, conforme combinamos, implementei as features de tornar o campo deadline obrigatorio e tambem coloquei um prazo padrao de sete dias corridos, conforme sugerido. Nao mexi na questao do tamanho do campo, pra colocar perto o calendario e o campo, porque acho que eh melhor mexer num contexto mais geral do layout desse form.

Por favor, facam ai os testes